### PR TITLE
LUN-636: Fix image plugin caption breaking layouts

### DIFF
--- a/cmsplugin_filer_image/templates/cmsplugin_filer_image/image.html
+++ b/cmsplugin_filer_image/templates/cmsplugin_filer_image/image.html
@@ -26,7 +26,7 @@
 {% endif %}
 {% if instance.caption or instance.description %}
 	<span class="info">
-		{% if instance.caption %}<span class="title">{{ instance.caption }}</span>{% endif %}
+		<!-- {% if instance.caption %}<span class="title">{{ instance.caption }}</span>{% endif %} -->
 		{% if instance.description %}<span class="desc">{{ instance.description }}</span>{% endif %}
 	</span>
 {% endif %}


### PR DESCRIPTION
- The image captions were breaking the layout of some sites.
- This is a temporary fix until we have a long-term solution.
