### PR TITLE
Lun 1086

### DIFF
--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -2,7 +2,7 @@ from cms.models import CMSPlugin
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from filer.fields.file import FilerFileField
-from filer.settings import FILER_STATICMEDIA_PREFIX
+from django.conf import settings
 
 from cmsplugin_filer_utils import FilerPluginManager
 
@@ -28,7 +28,7 @@ class FilerFile(CMSPlugin):
         return self.file.icons['32']
 
     def get_adjusted_icon_url(self):
-        return self.get_icon_url().replace(FILER_STATICMEDIA_PREFIX, "", 1)
+        return self.get_icon_url().replace(settings.STATIC_URL, "", 1)
 
     def file_exists(self):
         return self.file.file.storage.exists(self.file.file.name)

--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -2,6 +2,7 @@ from cms.models import CMSPlugin
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from filer.fields.file import FilerFileField
+from filer.settings import FILER_STATICMEDIA_PREFIX
 
 from cmsplugin_filer_utils import FilerPluginManager
 
@@ -25,6 +26,9 @@ class FilerFile(CMSPlugin):
 
     def get_icon_url(self):
         return self.file.icons['32']
+
+    def get_adjusted_icon_url(self):
+        return self.get_icon_url().replace(FILER_STATICMEDIA_PREFIX, "", 1)
 
     def file_exists(self):
         return self.file.file.storage.exists(self.file.file.name)

--- a/cmsplugin_filer_file/templates/cmsplugin_filer_file/file.html
+++ b/cmsplugin_filer_file/templates/cmsplugin_filer_file/file.html
@@ -1,7 +1,7 @@
 {% if object.file.url %}
 <span class="file" {% if inherited_from_parent %} style="{{inherited_from_parent.style}}" {% endif %} >
 <a href="{{ object.file.url }}"{% if object.target_blank %} target="_blank"{% endif %}>
-{% if object.get_icon_url %}<img src="{{ object.get_icon_url }}" style="border: 0px" alt="Icon" />{% endif %}
+{% if object.get_icon_url %}<img src="{{STATIC_URL}}{{ object.get_adjusted_icon_url }}" style="border: 0px" alt="Icon" />{% endif %}
 {% if object.title %}{{ object.title }}{% else %}{{ object.get_file_name }}{% endif %} {% if object.file_exists %}<span class="filesize">({{ object.file.size|filesizeformat }})</span>{% else %}(file missing!){% endif %}</a>
 </span>
 {% endif %}


### PR DESCRIPTION
the original object.get_icon_url from file.html is generated as

/s/filer/icons/file_32x32.png

So in the template I need a value without /s/  (this is object.get_adjusted_icon_url), and by prefixing {{STATIC_URL}} the correct (proxied) url will be generated in the template.
