### PR TITLE
(LUN-1147) Links for pages on other sites are build correctly

### DIFF
--- a/cmsplugin_filer_image/models.py
+++ b/cmsplugin_filer_image/models.py
@@ -8,6 +8,7 @@ from filer.fields.file import FilerFileField
 from cmsplugin_filer_utils import FilerPluginManager
 from distutils.version import LooseVersion
 from django.core.exceptions import ValidationError
+from django.contrib.sites.models import Site
 import filer
 
 
@@ -293,6 +294,10 @@ class FilerImage(CMSPlugin):
         if self.link_options == self.OPT_ADD_LINK:
             return self.free_link
         elif self.link_options == self.OPT_PAGE_LINK:
+            current_site = Site.objects.get_current()
+            if current_site.pk != self.page_link.site.pk:
+                return 'http://%s%s' % (self.page_link.site.domain,
+                                        self.page_link.get_absolute_url())
             return self.page_link.get_absolute_url()
         elif (self.link_options == self.OPT_FILE_LINK and
                 self.has_attached_file_link()):


### PR DESCRIPTION
If the page_link contained a page from a different site than the current site, the resulting URL was messed up, containing the absolute URL of the page and the domain of the current site. Fixed this by adding the correct domain name for a page's site that is different than the current one.
